### PR TITLE
RSS improvements: failure tracking, images, and UK dates

### DIFF
--- a/src/db/__tests__/rss.spec.ts
+++ b/src/db/__tests__/rss.spec.ts
@@ -1,6 +1,14 @@
 import assert from 'assert/strict'
 import { describe, it } from 'node:test'
-import { initRssDatabase, isEntryPosted, markEntryPosted } from '../rss.js'
+import {
+  getFeedHealth,
+  initRssDatabase,
+  isEntryPosted,
+  markEntryPosted,
+  markFeedNotified,
+  recordFeedFailure,
+  recordFeedSuccess,
+} from '../rss.js'
 import { randomUUID } from 'crypto'
 
 describe('db/rss.ts', () => {
@@ -16,5 +24,33 @@ describe('db/rss.ts', () => {
     const guid = randomUUID();
     markEntryPosted('https://example.com', guid, 'test entry');
     assert.ok(isEntryPosted('https://example.com', guid))
+  })
+})
+
+describe('db/rss.ts feed health', () => {
+  it('has no health row for an unknown feed', () => {
+    initRssDatabase();
+    assert.equal(getFeedHealth(`https://${randomUUID()}.example.com`), null);
+  })
+  it('counts consecutive failures', () => {
+    const url = `https://${randomUUID()}.example.com/feed.xml`;
+    assert.equal(recordFeedFailure(url, 'ETIMEDOUT', 1000), 1);
+    assert.equal(recordFeedFailure(url, 'ETIMEDOUT', 2000), 2);
+    const health = getFeedHealth(url);
+    assert.equal(health?.consecutive_failures, 2);
+    assert.equal(health?.last_error, 'ETIMEDOUT');
+    assert.equal(health?.next_retry_at, 2000);
+  })
+  it('resets on success, including the notified flag', () => {
+    const url = `https://${randomUUID()}.example.com/feed.xml`;
+    recordFeedFailure(url, 'boom', 1000);
+    markFeedNotified(url);
+    assert.equal(getFeedHealth(url)?.notified, 1);
+    recordFeedSuccess(url);
+    const health = getFeedHealth(url);
+    assert.equal(health?.consecutive_failures, 0);
+    assert.equal(health?.last_error, null);
+    assert.equal(health?.next_retry_at, null);
+    assert.equal(health?.notified, 0);
   })
 })

--- a/src/db/rss.ts
+++ b/src/db/rss.ts
@@ -25,6 +25,14 @@ export function initRssDatabase(): void {
       UNIQUE(feed_url, entry_guid)
     );
     CREATE INDEX IF NOT EXISTS idx_rss_feed_url ON rss_posted(feed_url);
+    CREATE TABLE IF NOT EXISTS rss_feed_health (
+      feed_url TEXT PRIMARY KEY,
+      consecutive_failures INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT,
+      last_failure_at INTEGER,
+      next_retry_at INTEGER,
+      notified INTEGER NOT NULL DEFAULT 0
+    );
   `);
 
   console.log(`[RSS DB] RSS tables initialized`);
@@ -62,6 +70,60 @@ export function markEntryPosted(
     VALUES (?, ?, ?)
   `);
   stmt.run(feedUrl, entryGuid, entryTitle);
+}
+
+export interface FeedHealth {
+  feed_url: string;
+  consecutive_failures: number;
+  last_error: string | null;
+  last_failure_at: number | null;
+  next_retry_at: number | null;
+  notified: number;
+}
+
+export function getFeedHealth(feedUrl: string): FeedHealth | null {
+  const stmt = getDb().prepare(`
+    SELECT * FROM rss_feed_health WHERE feed_url = ?
+  `);
+  return (stmt.get(feedUrl) as FeedHealth | undefined) ?? null;
+}
+
+// Returns the new consecutive failure count. nextRetryAt is a unix timestamp (seconds).
+export function recordFeedFailure(
+  feedUrl: string,
+  error: string,
+  nextRetryAt: number
+): number {
+  const stmt = getDb().prepare(`
+    INSERT INTO rss_feed_health (feed_url, consecutive_failures, last_error, last_failure_at, next_retry_at)
+    VALUES (?, 1, ?, unixepoch(), ?)
+    ON CONFLICT(feed_url) DO UPDATE SET
+      consecutive_failures = consecutive_failures + 1,
+      last_error = excluded.last_error,
+      last_failure_at = excluded.last_failure_at,
+      next_retry_at = excluded.next_retry_at
+    RETURNING consecutive_failures
+  `);
+  const row = stmt.get(feedUrl, error, nextRetryAt) as {
+    consecutive_failures: number;
+  };
+  return row.consecutive_failures;
+}
+
+export function recordFeedSuccess(feedUrl: string): void {
+  const stmt = getDb().prepare(`
+    UPDATE rss_feed_health
+    SET consecutive_failures = 0, last_error = NULL, next_retry_at = NULL, notified = 0
+    WHERE feed_url = ?
+  `);
+  stmt.run(feedUrl);
+}
+
+export function markFeedNotified(feedUrl: string): void {
+  const stmt = getDb().prepare(`
+    UPDATE rss_feed_health SET notified = 1 WHERE feed_url = ?
+  `);
+  stmt.run(feedUrl);
 }
 
 export function getPostedEntries(feedUrl?: string): RssPosted[] {

--- a/src/rss/__tests__/parser.spec.ts
+++ b/src/rss/__tests__/parser.spec.ts
@@ -1,0 +1,72 @@
+import assert from 'assert/strict'
+import { describe, it } from 'node:test'
+import { extractImageUrl } from '../parser.js'
+
+// extractImageUrl takes a loose rss-parser item; cast the fixtures to match.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const item = (fields: Record<string, unknown>) => fields as any
+
+describe('rss/parser.ts extractImageUrl', () => {
+  it('prefers an image enclosure', () => {
+    assert.equal(
+      extractImageUrl(item({ enclosure: { url: 'https://x.test/a.jpg', type: 'image/jpeg' } })),
+      'https://x.test/a.jpg'
+    )
+  })
+
+  it('ignores a non-image enclosure', () => {
+    assert.equal(
+      extractImageUrl(item({ enclosure: { url: 'https://x.test/a.mp3', type: 'audio/mpeg' } })),
+      null
+    )
+  })
+
+  it('reads media:content with medium=image', () => {
+    assert.equal(
+      extractImageUrl(item({ mediaContent: [{ $: { url: 'https://x.test/b.png', medium: 'image' } }] })),
+      'https://x.test/b.png'
+    )
+  })
+
+  it('reads a single (non-array) media:content node', () => {
+    assert.equal(
+      extractImageUrl(item({ mediaContent: { $: { url: 'https://x.test/c.jpg', type: 'image/jpeg' } } })),
+      'https://x.test/c.jpg'
+    )
+  })
+
+  it('reads media:content by url extension when medium/type absent', () => {
+    assert.equal(
+      extractImageUrl(item({ mediaContent: [{ $: { url: 'https://x.test/d.webp' } }] })),
+      'https://x.test/d.webp'
+    )
+  })
+
+  it('falls back to media:thumbnail', () => {
+    assert.equal(
+      extractImageUrl(item({ mediaThumbnail: [{ $: { url: 'https://x.test/t.jpg' } }] })),
+      'https://x.test/t.jpg'
+    )
+  })
+
+  it('falls back to the first <img> in content', () => {
+    assert.equal(
+      extractImageUrl(item({ content: '<p>hi</p><img src="https://x.test/e.png" alt="x">' })),
+      'https://x.test/e.png'
+    )
+  })
+
+  it('rejects a relative <img> src', () => {
+    assert.equal(
+      extractImageUrl(item({ content: '<img src="/images/rel.png">' })),
+      null
+    )
+  })
+
+  it('returns null when there is no image', () => {
+    assert.equal(
+      extractImageUrl(item({ content: '<p>no pictures here</p>' })),
+      null
+    )
+  })
+})

--- a/src/rss/__tests__/sync.spec.ts
+++ b/src/rss/__tests__/sync.spec.ts
@@ -1,0 +1,20 @@
+import assert from 'assert/strict'
+import { describe, it } from 'node:test'
+import { computeBackoffMs } from '../sync.js'
+
+describe('rss/sync.ts computeBackoffMs', () => {
+  const MINUTE = 60 * 1000;
+
+  it('retries on the next poll after the first failure', () => {
+    assert.equal(computeBackoffMs(1, 5), 5 * MINUTE);
+  })
+  it('doubles with each consecutive failure', () => {
+    assert.equal(computeBackoffMs(2, 5), 10 * MINUTE);
+    assert.equal(computeBackoffMs(3, 5), 20 * MINUTE);
+    assert.equal(computeBackoffMs(5, 5), 80 * MINUTE);
+  })
+  it('caps at 6 hours', () => {
+    assert.equal(computeBackoffMs(10, 5), 360 * MINUTE);
+    assert.equal(computeBackoffMs(100, 5), 360 * MINUTE);
+  })
+})

--- a/src/rss/parser.ts
+++ b/src/rss/parser.ts
@@ -1,9 +1,29 @@
 import Parser from "rss-parser";
 
-const parser = new Parser({
+// Custom fields we pull out of feeds for image extraction. rss-parser maps
+// content:encoded to `content` by default, but media:* need declaring.
+interface FeedItemFields {
+  mediaContent?: MediaNode | MediaNode[];
+  mediaThumbnail?: MediaNode | MediaNode[];
+  // Supplying a custom item type drops rss-parser's index signature, so
+  // re-declare the non-core fields we read off items.
+  author?: string;
+}
+
+interface MediaNode {
+  $?: { url?: string; medium?: string; type?: string };
+}
+
+const parser: Parser<unknown, FeedItemFields> = new Parser({
   timeout: 10000,
   headers: {
     "User-Agent": "donna-bot/1.0 RSS Reader",
+  },
+  customFields: {
+    item: [
+      ["media:content", "mediaContent", { keepArray: true }],
+      ["media:thumbnail", "mediaThumbnail", { keepArray: true }],
+    ],
   },
 });
 
@@ -14,12 +34,74 @@ export interface RssEntry {
   pubDate: Date | null;
   description: string | null;
   author: string | null;
+  imageUrl: string | null;
 }
 
 export interface ParsedFeed {
   feedUrl: string;
   feedTitle: string | null;
   entries: RssEntry[];
+}
+
+const IMAGE_EXT = /\.(jpe?g|png|gif|webp)(\?|$)/i;
+
+function isHttpUrl(url: string | undefined): url is string {
+  if (!url) return false;
+  try {
+    const u = new URL(url);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+// True when a node's type/medium marks it an image, or (absent those) its URL
+// has an image extension. A bare valid URL is not enough.
+function isImageNode(url: string | undefined, type?: string, medium?: string): boolean {
+  if (!isHttpUrl(url)) return false;
+  if (medium === "image") return true;
+  if (type?.startsWith("image/")) return true;
+  if (!type && !medium) return IMAGE_EXT.test(url);
+  return false;
+}
+
+// Pick the first usable image from an item, in order of reliability:
+// enclosure, media:content, media:thumbnail, then a raw <img> in the content HTML.
+function extractImageUrl(
+  item: Parser.Item & FeedItemFields & { content?: string }
+): string | null {
+  if (
+    item.enclosure &&
+    isImageNode(item.enclosure.url, item.enclosure.type)
+  ) {
+    return item.enclosure.url ?? null;
+  }
+
+  for (const node of toArray(item.mediaContent)) {
+    if (isImageNode(node.$?.url, node.$?.type, node.$?.medium)) {
+      return node.$?.url ?? null;
+    }
+  }
+
+  for (const node of toArray(item.mediaThumbnail)) {
+    // media:thumbnail is image-by-definition, so any valid URL qualifies.
+    if (isHttpUrl(node.$?.url)) {
+      return node.$?.url ?? null;
+    }
+  }
+
+  const html = item.content ?? "";
+  const match = html.match(/<img[^>]+src=["']([^"']+)["']/i);
+  if (match && isHttpUrl(match[1])) {
+    return match[1];
+  }
+
+  return null;
 }
 
 export async function parseFeed(feedUrl: string): Promise<ParsedFeed> {
@@ -33,6 +115,7 @@ export async function parseFeed(feedUrl: string): Promise<ParsedFeed> {
     pubDate: item.pubDate ? new Date(item.pubDate) : null,
     description: item.contentSnippet || item.content || null,
     author: item.creator || item.author || null,
+    imageUrl: extractImageUrl(item),
   }));
 
   return {
@@ -41,3 +124,5 @@ export async function parseFeed(feedUrl: string): Promise<ParsedFeed> {
     entries,
   };
 }
+
+export { extractImageUrl };

--- a/src/rss/sync.ts
+++ b/src/rss/sync.ts
@@ -13,6 +13,7 @@ import { parseFeed, RssEntry } from "./parser.js";
 
 const EMBED_COLOR = 0x5865f2; // Discord blurple
 const MAX_AGE_DAYS = 60; // Only post entries from the last 60 days
+const DISPLAY_TIMEZONE = "Europe/London"; // Show dates in UK time regardless of container TZ
 const FAILURE_NOTIFY_THRESHOLD = 5; // Post a channel notice after this many consecutive failures
 const MAX_BACKOFF_MS = 6 * 60 * 60 * 1000; // Never back off longer than 6 hours
 
@@ -55,7 +56,9 @@ function createEmbed(entry: RssEntry, feedTitle: string | null): EmbedBuilder {
     footerParts.push(extractDomain(entry.link));
   }
   if (entry.pubDate) {
-    footerParts.push(entry.pubDate.toLocaleDateString("en-GB"));
+    footerParts.push(
+      entry.pubDate.toLocaleDateString("en-GB", { timeZone: DISPLAY_TIMEZONE })
+    );
   }
   if (footerParts.length > 0) {
     embed.setFooter({ text: footerParts.join(" • ") });
@@ -63,6 +66,10 @@ function createEmbed(entry: RssEntry, feedTitle: string | null): EmbedBuilder {
 
   if (entry.author) {
     embed.setAuthor({ name: entry.author });
+  }
+
+  if (entry.imageUrl) {
+    embed.setImage(entry.imageUrl);
   }
 
   return embed;

--- a/src/rss/sync.ts
+++ b/src/rss/sync.ts
@@ -1,11 +1,29 @@
 import { Client, EmbedBuilder, TextChannel } from "discord.js";
 import { config } from "../config.js";
-import { isEntryPosted, markEntryPosted } from "../db/rss.js";
+import {
+  getFeedHealth,
+  isEntryPosted,
+  markEntryPosted,
+  markFeedNotified,
+  recordFeedFailure,
+  recordFeedSuccess,
+} from "../db/rss.js";
 import { loadFeedUrls } from "./feeds.js";
 import { parseFeed, RssEntry } from "./parser.js";
 
 const EMBED_COLOR = 0x5865f2; // Discord blurple
 const MAX_AGE_DAYS = 60; // Only post entries from the last 60 days
+const FAILURE_NOTIFY_THRESHOLD = 5; // Post a channel notice after this many consecutive failures
+const MAX_BACKOFF_MS = 6 * 60 * 60 * 1000; // Never back off longer than 6 hours
+
+// Exponential backoff: first failure retries on the next poll, then doubles, capped at MAX_BACKOFF_MS
+export function computeBackoffMs(
+  consecutiveFailures: number,
+  pollIntervalMinutes: number
+): number {
+  const baseMs = pollIntervalMinutes * 60 * 1000;
+  return Math.min(baseMs * 2 ** (consecutiveFailures - 1), MAX_BACKOFF_MS);
+}
 
 function truncate(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
@@ -37,7 +55,7 @@ function createEmbed(entry: RssEntry, feedTitle: string | null): EmbedBuilder {
     footerParts.push(extractDomain(entry.link));
   }
   if (entry.pubDate) {
-    footerParts.push(entry.pubDate.toLocaleDateString());
+    footerParts.push(entry.pubDate.toLocaleDateString("en-GB"));
   }
   if (footerParts.length > 0) {
     embed.setFooter({ text: footerParts.join(" • ") });
@@ -48,6 +66,15 @@ function createEmbed(entry: RssEntry, feedTitle: string | null): EmbedBuilder {
   }
 
   return embed;
+}
+
+// A failed notice must never abort the sync loop for the remaining feeds
+async function sendNotice(channel: TextChannel, content: string): Promise<void> {
+  try {
+    await channel.send({ content });
+  } catch (error) {
+    console.error("[RSS] Failed to send channel notice:", error);
+  }
 }
 
 export async function syncFeeds(client: Client): Promise<void> {
@@ -70,6 +97,13 @@ export async function syncFeeds(client: Client): Promise<void> {
   let totalNew = 0;
 
   for (const feedUrl of feedUrls) {
+    const health = getFeedHealth(feedUrl);
+
+    // Feed is backing off after repeated failures; skip until its retry time
+    if (health?.next_retry_at && Date.now() < health.next_retry_at * 1000) {
+      continue;
+    }
+
     try {
       const feed = await parseFeed(feedUrl);
       const newEntries: RssEntry[] = [];
@@ -100,8 +134,38 @@ export async function syncFeeds(client: Client): Promise<void> {
         totalNew++;
         console.log(`[RSS] Posted: ${entry.title}`);
       }
+
+      if (health && health.consecutive_failures > 0) {
+        console.log(
+          `[RSS] Feed recovered after ${health.consecutive_failures} failures: ${feedUrl}`
+        );
+        if (health.notified) {
+          await sendNotice(channel, `✅ RSS feed <${feedUrl}> is working again.`);
+        }
+      }
+      recordFeedSuccess(feedUrl);
     } catch (error) {
-      console.error(`[RSS] Error fetching ${feedUrl}:`, error);
+      const message = error instanceof Error ? error.message : String(error);
+      const backoffMs = computeBackoffMs(
+        (health?.consecutive_failures ?? 0) + 1,
+        config.rss.pollIntervalMinutes
+      );
+      const nextRetryAt = Math.floor((Date.now() + backoffMs) / 1000);
+      const failures = recordFeedFailure(feedUrl, message, nextRetryAt);
+      console.error(
+        `[RSS] Error fetching ${feedUrl} (failure #${failures}, retrying in ${Math.round(backoffMs / 60000)} min):`,
+        error
+      );
+
+      if (failures >= FAILURE_NOTIFY_THRESHOLD && !health?.notified) {
+        await sendNotice(
+          channel,
+          `⚠️ RSS feed <${feedUrl}> has failed ${failures} times in a row ` +
+            `(last error: ${truncate(message, 200)}). ` +
+            `I'll keep retrying (backing off up to every 6 hours) and post here when it recovers.`
+        );
+        markFeedNotified(feedUrl);
+      }
     }
   }
 


### PR DESCRIPTION
Bundles three small RSS fixes that all touch the same sync/parser code.

## 1. Per-feed failure tracking (fixes the noise in #13, #14)

- Failing feeds back off exponentially instead of retrying every poll forever: first failure retries on the next poll, then the wait doubles per consecutive failure, capped at 6 hours.
- After 5 consecutive failures the bot posts a warning to the RSS channel with the last error, and a recovery notice when the feed works again. Self-healing, no manual re-enable.
- State lives in a new `rss_feed_health` SQLite table, created via `CREATE TABLE IF NOT EXISTS` so existing databases migrate on startup.

A permanently-dead feed drops from ~288 log lines a day to 4, and a human gets told once. #13 turned out to be a transient outage (verified recovered, closed separately); #14 is an upstream bot-blocker on the feed, out of our hands, but this stops it flooding the logs.

## 2. Images in embeds (closes #8)

Per-entry image pulled from, in order of reliability: `enclosure`, `media:content`, `media:thumbnail`, then the first `<img>` in the content HTML. Set via `embed.setImage()`. Feeds without images are unaffected (verified against kim.town, which has none, and gfsc.community, which uses media:content).

## 3. UK dates (closes #12)

Footer dates now use `en-GB` format **and** `timeZone: Europe/London`, so the shown date is correct UK local date regardless of the container's timezone (Docker defaults to UTC), not just dd/mm/yyyy formatting.

## Notes for review

- Verified image extraction end-to-end against the live gfsc.community feed, not just unit tests.
- Channel notices go through a helper that swallows send errors, so a Discord hiccup can't abort the sync loop for other feeds.
- Error log lines keep the `Error fetching <url>` prefix, so existing Loki queries still match.
- Tests: 19 passing (health-table CRUD, backoff curve, image extraction across all four source types). Runs under Node 22. Heads-up unrelated to this PR: better-sqlite3 has no prebuilt binary for Node 26 and won't compile there, so local dev needs Node 22 (matches `engines` and the Docker image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)