### PR TITLE
Add /tickets command to list your open GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ GOOGLE_CALENDAR_ID=calendar_id@group.calendar.google.com
 RSS_CHANNEL_ID=discord_channel_id
 RSS_FEEDS_PATH=./config/rss-feeds.txt
 RSS_POLL_INTERVAL_MINUTES=5
+
+# GitHub tickets (optional)
+GITHUB_ORG=geeksforsocialchange
+# Token is optional; raises API rate limits. Public repos work without it.
+GITHUB_TOKEN=
 ```
 
 ### 4. Run Locally
@@ -71,6 +76,8 @@ npm run dev
 - `/list-mappings` - List all Discord → Google Calendar event mappings
 - `/list-feeds` - List configured RSS feeds
 - `/refresh-feeds` - Manually check RSS feeds for new entries
+- `/gh-link <username>` - Link your GitHub username to your Discord account
+- `/tickets [username]` - List your open GitHub issues in the GFSC org (authored or assigned)
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm run dev
 - `/list-feeds` - List configured RSS feeds
 - `/refresh-feeds` - Manually check RSS feeds for new entries
 - `/gh-link <username>` - Link your GitHub username to your Discord account
-- `/tickets [username]` - List your open GitHub issues in the GFSC org (authored or assigned)
+- `/tickets` - List your open GitHub issues in the GFSC org (authored or assigned; requires `/gh-link`)
 
 ## How It Works
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,11 @@ export const config = {
       10,
     ),
   },
+  github: {
+    org: process.env.GITHUB_ORG || "geeksforsocialchange",
+    // Optional: raises API rate limits; public org repos work without it
+    token: process.env.GITHUB_TOKEN || "",
+  },
   databasePath: process.env.DATABASE_PATH || "./data/donna.db",
   // Environment: "production", "development", or unset (defaults to production behavior)
   environment: process.env.NODE_ENV || "production",

--- a/src/db/__tests__/links.spec.ts
+++ b/src/db/__tests__/links.spec.ts
@@ -1,0 +1,24 @@
+import assert from 'assert/strict'
+import { describe, it } from 'node:test'
+import { initLinksDatabase, setGithubLink, getGithubLink } from '../links.js'
+import { randomUUID } from 'crypto'
+
+describe('db/links.ts', () => {
+  it('initialises a database', () => {
+    initLinksDatabase();
+  })
+  it('returns null for an unlinked user', () => {
+    assert.equal(getGithubLink(randomUUID()), null);
+  })
+  it('stores and retrieves a link', () => {
+    const discordId = randomUUID();
+    setGithubLink(discordId, 'octocat');
+    assert.equal(getGithubLink(discordId), 'octocat');
+  })
+  it('overwrites an existing link', () => {
+    const discordId = randomUUID();
+    setGithubLink(discordId, 'octocat');
+    setGithubLink(discordId, 'monalisa');
+    assert.equal(getGithubLink(discordId), 'monalisa');
+  })
+})

--- a/src/db/links.ts
+++ b/src/db/links.ts
@@ -1,0 +1,60 @@
+import Database from "better-sqlite3";
+import { mkdirSync, existsSync } from "fs";
+import { dirname } from "path";
+import { config } from "../config.js";
+
+let db: Database.Database | null = null;
+
+export function initLinksDatabase(): void {
+  const dbPath = config.databasePath;
+  const dbDir = dirname(dbPath);
+
+  if (!existsSync(dbDir)) {
+    mkdirSync(dbDir, { recursive: true });
+  }
+
+  db = new Database(dbPath);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS github_links (
+      discord_id TEXT PRIMARY KEY,
+      github_username TEXT NOT NULL,
+      linked_at INTEGER DEFAULT (unixepoch())
+    );
+  `);
+
+  console.log(`[GitHub DB] GitHub tables initialized`);
+}
+
+function getDb(): Database.Database {
+  if (!db) {
+    throw new Error(
+      "GitHub Database not initialized. Call initLinksDatabase() first.",
+    );
+  }
+  return db;
+}
+
+export function setGithubLink(
+  discordUserId: string,
+  githubUsername: string,
+): void {
+  const stmt = getDb().prepare(`
+    INSERT INTO github_links (discord_id, github_username)
+    VALUES (?, ?)
+    ON CONFLICT(discord_id) DO UPDATE SET
+      github_username = excluded.github_username,
+      linked_at = unixepoch()
+  `);
+  stmt.run(discordUserId, githubUsername);
+}
+
+export function getGithubLink(discordUserId: string): string | null {
+  const stmt = getDb().prepare(`
+    SELECT github_username FROM github_links WHERE discord_id = ?
+  `);
+  const row = stmt.get(discordUserId) as
+    | { github_username: string }
+    | undefined;
+  return row?.github_username ?? null;
+}

--- a/src/github/__tests__/api.spec.ts
+++ b/src/github/__tests__/api.spec.ts
@@ -1,0 +1,56 @@
+import assert from 'assert/strict'
+import { describe, it } from 'node:test'
+import { formatIssueLines, isValidGithubUsername, GithubIssue } from '../api.js'
+
+describe('github/api.ts isValidGithubUsername', () => {
+  it('accepts normal usernames', () => {
+    assert.ok(isValidGithubUsername('octocat'));
+    assert.ok(isValidGithubUsername('kimadactyl'));
+    assert.ok(isValidGithubUsername('a-b-c'));
+    assert.ok(isValidGithubUsername('user123'));
+  })
+  it('rejects invalid usernames', () => {
+    assert.equal(isValidGithubUsername(''), false);
+    assert.equal(isValidGithubUsername('-leading'), false);
+    assert.equal(isValidGithubUsername('trailing-'), false);
+    assert.equal(isValidGithubUsername('double--hyphen'), false);
+    assert.equal(isValidGithubUsername('has space'), false);
+    assert.equal(isValidGithubUsername('a'.repeat(40)), false);
+    // Query injection attempts must not validate
+    assert.equal(isValidGithubUsername('x org:evil'), false);
+  })
+})
+
+describe('github/api.ts formatIssueLines', () => {
+  const issue = (over: Partial<GithubIssue>): GithubIssue => ({
+    title: 'A bug',
+    htmlUrl: 'https://github.com/org/repo/issues/1',
+    repoName: 'repo',
+    number: 1,
+    isAssigned: false,
+    ...over,
+  })
+
+  it('groups by repo and sorts by issue number', () => {
+    const lines = formatIssueLines([
+      issue({ repoName: 'zeta', number: 9, title: 'z issue' }),
+      issue({ repoName: 'alpha', number: 3, title: 'later' }),
+      issue({ repoName: 'alpha', number: 1, title: 'first' }),
+    ]);
+    assert.equal(lines[0], '**alpha**');
+    assert.match(lines[1], /#1 first/);
+    assert.match(lines[2], /#3 later/);
+    assert.equal(lines[3], '**zeta**');
+    assert.match(lines[4], /#9 z issue/);
+  })
+
+  it('marks assigned issues', () => {
+    const lines = formatIssueLines([issue({ isAssigned: true })]);
+    assert.match(lines[1], /\(assigned\)$/);
+  })
+
+  it('wraps URLs in <> to suppress Discord previews', () => {
+    const lines = formatIssueLines([issue({})]);
+    assert.match(lines[1], /\(<https:\/\/github\.com\/org\/repo\/issues\/1>\)/);
+  })
+})

--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -1,0 +1,92 @@
+import { config } from "../config.js";
+
+export interface GithubIssue {
+  title: string;
+  htmlUrl: string;
+  repoName: string; // e.g. "donna-bot"
+  number: number;
+  isAssigned: boolean;
+}
+
+// GitHub usernames: alphanumerics and hyphens, max 39 chars
+export function isValidGithubUsername(username: string): boolean {
+  return /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(username);
+}
+
+interface SearchResultItem {
+  title: string;
+  html_url: string;
+  number: number;
+  repository_url: string; // https://api.github.com/repos/<owner>/<repo>
+}
+
+async function searchIssues(query: string): Promise<SearchResultItem[]> {
+  const url = new URL("https://api.github.com/search/issues");
+  url.searchParams.set("q", query);
+  url.searchParams.set("per_page", "50");
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "donna-bot/1.0",
+  };
+  if (config.github.token) {
+    headers.Authorization = `Bearer ${config.github.token}`;
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API returned ${response.status} for query "${query}"`,
+    );
+  }
+
+  const body = (await response.json()) as { items?: SearchResultItem[] };
+  return body.items ?? [];
+}
+
+// Open issues in the configured org that the user authored or is assigned to
+export async function fetchOpenIssues(
+  githubUsername: string,
+): Promise<GithubIssue[]> {
+  const org = config.github.org;
+  const base = `org:${org} is:issue is:open`;
+
+  const [authored, assigned] = await Promise.all([
+    searchIssues(`${base} author:${githubUsername}`),
+    searchIssues(`${base} assignee:${githubUsername}`),
+  ]);
+
+  const assignedUrls = new Set(assigned.map((i) => i.html_url));
+  const byUrl = new Map<string, SearchResultItem>();
+  for (const item of [...authored, ...assigned]) {
+    byUrl.set(item.html_url, item);
+  }
+
+  return [...byUrl.values()].map((item) => ({
+    title: item.title,
+    htmlUrl: item.html_url,
+    repoName: item.repository_url.split("/").pop() ?? "",
+    number: item.number,
+    isAssigned: assignedUrls.has(item.html_url),
+  }));
+}
+
+// Discord message lines for a list of issues, grouped by repo
+export function formatIssueLines(issues: GithubIssue[]): string[] {
+  const byRepo = new Map<string, GithubIssue[]>();
+  for (const issue of issues) {
+    const list = byRepo.get(issue.repoName) ?? [];
+    list.push(issue);
+    byRepo.set(issue.repoName, list);
+  }
+
+  const lines: string[] = [];
+  for (const [repo, repoIssues] of [...byRepo.entries()].sort()) {
+    lines.push(`**${repo}**`);
+    for (const issue of repoIssues.sort((a, b) => a.number - b.number)) {
+      const assigned = issue.isAssigned ? " (assigned)" : "";
+      lines.push(`• [#${issue.number} ${issue.title}](<${issue.htmlUrl}>)${assigned}`);
+    }
+  }
+  return lines;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,13 +54,7 @@ async function registerCommands(): Promise<void> {
       ),
     new SlashCommandBuilder()
       .setName("tickets")
-      .setDescription("List your open GitHub issues in the GFSC org")
-      .addStringOption((option) =>
-        option
-          .setName("username")
-          .setDescription("GitHub username (defaults to your linked one)")
-          .setRequired(false),
-      ),
+      .setDescription("List your open GitHub issues in the GFSC org"),
   ];
 
   const rest = new REST().setToken(config.discord.token);
@@ -263,18 +257,12 @@ client.on("interactionCreate", async (interaction) => {
       return;
     }
     try {
-      const username =
-        interaction.options.getString("username")?.trim() ||
-        getGithubLink(interaction.user.id);
+      // Only ever show the caller their own linked account, so nobody can
+      // pull up someone else's task list
+      const username = getGithubLink(interaction.user.id);
       if (!username) {
         await interaction.editReply(
-          "I don't know your GitHub username. Run `/gh-link` first, or pass a username to `/tickets`.",
-        );
-        return;
-      }
-      if (!isValidGithubUsername(username)) {
-        await interaction.editReply(
-          `\`${username.slice(0, 50)}\` doesn't look like a valid GitHub username.`,
+          "I don't know your GitHub username. Run `/gh-link <username>` first.",
         );
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,12 @@ import { config } from "./config.js";
 import { registerEventHandlers } from "./discord/events.js";
 import { initDatabase, getAllMappings } from "./db/mappings.js";
 import { initRssDatabase } from "./db/rss.js";
+import { initLinksDatabase, setGithubLink, getGithubLink } from "./db/links.js";
+import {
+  fetchOpenIssues,
+  formatIssueLines,
+  isValidGithubUsername,
+} from "./github/api.js";
 import { bulkSyncEvents, cleanupOrphanedEvents } from "./sync/eventSync.js";
 import { startRssPoller } from "./rss/poller.js";
 import { loadFeedUrls } from "./rss/feeds.js";
@@ -37,6 +43,24 @@ async function registerCommands(): Promise<void> {
     new SlashCommandBuilder()
       .setName("refresh-feeds")
       .setDescription("Manually check all RSS feeds for new entries"),
+    new SlashCommandBuilder()
+      .setName("gh-link")
+      .setDescription("Link your GitHub username so /tickets knows who you are")
+      .addStringOption((option) =>
+        option
+          .setName("username")
+          .setDescription("Your GitHub username")
+          .setRequired(true),
+      ),
+    new SlashCommandBuilder()
+      .setName("tickets")
+      .setDescription("List your open GitHub issues in the GFSC org")
+      .addStringOption((option) =>
+        option
+          .setName("username")
+          .setDescription("GitHub username (defaults to your linked one)")
+          .setRequired(false),
+      ),
   ];
 
   const rest = new REST().setToken(config.discord.token);
@@ -204,6 +228,79 @@ client.on("interactionCreate", async (interaction) => {
       );
     }
   }
+
+  if (interaction.commandName === "gh-link") {
+    console.log("[GitHub] /gh-link command received");
+    const username = interaction.options.getString("username", true).trim();
+    if (!isValidGithubUsername(username)) {
+      await interaction.reply({
+        content: `\`${username.slice(0, 50)}\` doesn't look like a valid GitHub username.`,
+        ephemeral: true,
+      });
+      return;
+    }
+    try {
+      setGithubLink(interaction.user.id, username);
+      await interaction.reply({
+        content: `Linked you to GitHub user \`${username}\`. Run /tickets to see your open issues.`,
+        ephemeral: true,
+      });
+    } catch (error) {
+      console.error("[GitHub] Link failed:", error);
+      await interaction.reply({
+        content: "Failed to save the link. Check logs for details.",
+        ephemeral: true,
+      });
+    }
+  }
+
+  if (interaction.commandName === "tickets") {
+    console.log("[GitHub] /tickets command received");
+    try {
+      await interaction.deferReply({ ephemeral: true });
+    } catch (error) {
+      console.error("[GitHub] Failed to defer reply:", error);
+      return;
+    }
+    try {
+      const username =
+        interaction.options.getString("username")?.trim() ||
+        getGithubLink(interaction.user.id);
+      if (!username) {
+        await interaction.editReply(
+          "I don't know your GitHub username. Run `/gh-link` first, or pass a username to `/tickets`.",
+        );
+        return;
+      }
+      if (!isValidGithubUsername(username)) {
+        await interaction.editReply(
+          `\`${username.slice(0, 50)}\` doesn't look like a valid GitHub username.`,
+        );
+        return;
+      }
+      const issues = await fetchOpenIssues(username);
+      if (issues.length === 0) {
+        await interaction.editReply(
+          `No open issues for \`${username}\` in the ${config.github.org} org. Enjoy the peace!`,
+        );
+        return;
+      }
+      const lines = formatIssueLines(issues);
+      const response =
+        `**${issues.length} open issue${issues.length === 1 ? "" : "s"} for \`${username}\`:**\n` +
+        lines.join("\n");
+      await interaction.editReply(
+        response.length > 1900
+          ? response.slice(0, 1900) + "\n... (truncated)"
+          : response,
+      );
+    } catch (error) {
+      console.error("[GitHub] Tickets lookup failed:", error);
+      await interaction.editReply(
+        "Failed to fetch issues from GitHub. Check logs for details.",
+      );
+    }
+  }
 });
 
 client.on("error", (error) => {
@@ -214,6 +311,7 @@ async function main(): Promise<void> {
   console.log("[Bot] Starting donna-bot...");
   initDatabase();
   initRssDatabase();
+  initLinksDatabase();
   await client.login(config.discord.token);
 }
 


### PR DESCRIPTION
Closes #9.

## What

Two new slash commands:

- `/gh-link <username>` saves your GitHub username against your Discord ID. Command name, module (`src/db/links.ts`), and schema (`github_links` with `discord_id`) follow the design in #16, so the rest of that issue (`/gh-unlink`, `/gh-whois`, people.yml sync) can build directly on this table with no migration. This PR implements only the link half; #16 stays open for the rest.
- `/tickets` lists open issues in the GFSC org that you authored or are assigned to, grouped by repo and sorted by issue number, with assigned ones marked. It only ever shows the account you linked yourself, so nobody can pull up someone else's task list. Replies are ephemeral so it doesn't spam the channel.

## Design notes

- Org is configurable via `GITHUB_ORG` (defaults to `geeksforsocialchange`). `GITHUB_TOKEN` is optional and only raises rate limits; public repos work unauthenticated.
- "Your tickets" means authored OR assigned: two GitHub search queries merged and deduped, since search qualifiers AND together and most GFSC issues have no assignee.
- Usernames are validated against GitHub's username rules before being interpolated into the search query, so nobody can inject extra search qualifiers.
- Issue links are wrapped in `<>` to suppress Discord link previews (one preview per issue would be chaos).
- Known limit: each search query caps at 50 results, and Discord's 2000-char message limit truncates long lists anyway.

## Verified

- 13 tests pass (link table CRUD, username validation including injection attempts, formatter grouping/sorting).
- Live end-to-end check against the real API: `fetchOpenIssues('kimadactyl')` returned 51 open issues across the org, correctly grouped by repo.
- Lint and build clean under Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)